### PR TITLE
refactor(auth): enforce access control for timeLog queries

### DIFF
--- a/routes/timeLogRoutes.ts
+++ b/routes/timeLogRoutes.ts
@@ -12,7 +12,7 @@ import { userAuthorized } from '../middlewares/authMiddleware';
 const timeLogRoutes = Router();
 
 timeLogRoutes.post('/', keycloak.protect(), userAuthorized, createTimeLog);
-timeLogRoutes.get('/', keycloak.protect('admin'), getAllTimeLogs);
+timeLogRoutes.get('/', keycloak.protect(), userAuthorized, getAllTimeLogs);
 timeLogRoutes.get('/:id', keycloak.protect(), userAuthorized, getTimeLogById);
 timeLogRoutes.put('/:id', keycloak.protect(), userAuthorized, updateTimeLog);
 timeLogRoutes.delete('/:id', keycloak.protect('admin'), deleteTimeLog);


### PR DESCRIPTION
- Updated logic in timeLog queries to restrict access to the authenticated employee or an admin.
- Used dynamic `where` conditions to ensure admins can query by ID, while regular employees are restricted to their own data.
- Improved security and maintained clarity in query logic.