### PR TITLE
Add PATCH method to update statusID in employee requests

### DIFF
--- a/controllers/leaveRequestController.ts
+++ b/controllers/leaveRequestController.ts
@@ -56,11 +56,15 @@ export const createLeaveRequest = async (req: Request, res: Response) => {
   }
 };
 
-export const updateLeaveRequest = async (req: Request, res: Response) => {
+export const updateLeaveRequest = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
   const { id } = req.params;
   const { startDate, endDate, typeId, statusId } = req.body;
   const employeeAuth = (req as any).employee;
   const isAdmin = (req as any).isAdmin;
+
   try {
     const leaveRequest = await LeaveRequest.findOne({
       where: {
@@ -68,12 +72,16 @@ export const updateLeaveRequest = async (req: Request, res: Response) => {
         ...(isAdmin ? {} : { employeeId: employeeAuth.id }),
       },
     });
+
     if (leaveRequest) {
-      leaveRequest.startDate = startDate;
-      leaveRequest.endDate = endDate;
-      leaveRequest.typeId = typeId;
-      leaveRequest.statusId = statusId;
+      if (startDate) leaveRequest.startDate = startDate;
+      if (endDate) leaveRequest.endDate = endDate;
+      if (typeId) leaveRequest.typeId = typeId;
+      if (statusId) leaveRequest.statusId = statusId; // Actualizamos el statusId
+
       await leaveRequest.save();
+
+      // Respondemos con la solicitud actualizada
       res.status(200).json(leaveRequest);
     } else {
       res
@@ -81,6 +89,7 @@ export const updateLeaveRequest = async (req: Request, res: Response) => {
         .json({ error: 'Leave request not found or user not authorized' });
     }
   } catch (error) {
+    console.error('Error updating leave request:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/routes/leaveRequestRoutes.ts
+++ b/routes/leaveRequestRoutes.ts
@@ -35,6 +35,12 @@ leaveRequestRoutes.put(
   userAuthorized,
   updateLeaveRequest
 );
+leaveRequestRoutes.patch(
+  '/:id',
+  keycloak.protect(),
+  userAuthorized,
+  updateLeaveRequest
+);
 leaveRequestRoutes.delete(
   '/:id',
   keycloak.protect(),


### PR DESCRIPTION
This PR introduces a PATCH method to allow updating the statusID of employee requests. The new method enables more flexible status management without modifying the entire request resource.